### PR TITLE
Removed dependency on Browsersync for testing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,16 @@ The latest build from master should always be at
 
 ## Building and Testing
 
-Requires [NodeJS]. Use [Grunt], [Browserify], and [Browsersync] to build and test the Web UI:
+Requires [NodeJS]. Use [Grunt] and [Browserify] to build and test the Web UI:
 
 ```
 # install the build tools
-npm -g install grunt-cli browserify browser-sync
+npm -g install grunt-cli browserify
 
 # build and run for testing
 npm install
 grunt
-browser-sync start --server build
+./server.js
 ```
 
 ## Command-Line Program
@@ -69,4 +69,3 @@ function non_negative(x) {
 [NodeJS]: https://nodejs.org/
 [Grunt]: https://gruntjs.com/
 [Browserify]: http://browserify.org/
-[Browsersync]: https://www.browsersync.io/

--- a/package.json
+++ b/package.json
@@ -3,9 +3,11 @@
   "version": "0.1.0",
   "devDependencies": {
     "brfs": "^1.4.3",
+    "connect": "^3.6.5",
     "grunt": "~0.4.5",
     "grunt-browserify": "^5.2.0",
-    "grunt-contrib-copy": "^1.0.0"
+    "grunt-contrib-copy": "^1.0.0",
+    "serve-static": "^1.13.1"
   },
   "homepage": "https://github.com/umd-coding-workshop/dpcc",
   "repository": "umd-coding-workshop/dpcc",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+
+var connect = require('connect');
+var serveStatic = require('serve-static');
+
+var args = process.argv.slice(2);
+var port = args[0] || 8080;
+
+connect().use(serveStatic(__dirname + '/build')).listen(port, function(){
+  console.log('Server running on port ' + port + '...');
+});


### PR DESCRIPTION
Instead, the local dev server is in the server.js script, and uses the
connect and serve-static modules to serve the build directory on port 8080 by
default.