### PR TITLE
Initialize the backing user and service objects.

### DIFF
--- a/docs/dpcc-web.js
+++ b/docs/dpcc-web.js
@@ -41,6 +41,7 @@ services.forEach(function (service, index) {
 
 
 get_service_inputs().forEach(function (element, index) {
+  window.service[element.name] = +element.value;
   element.onchange = function (event) {
     window.service[element.name] = +this.value;
     display_costs();
@@ -49,6 +50,7 @@ get_service_inputs().forEach(function (element, index) {
 
 
 get_user_inputs().forEach(function (element, index) {
+  window.user[element.name] = +element.value;
   element.onchange = function (event) {
     window.user[element.name] = +this.value;
     display_costs();
@@ -198,7 +200,7 @@ function fromByteArray (uint8) {
 /*!
  * The buffer module from node.js, for the browser.
  *
- * @author   Feross Aboukhadijeh <feross@feross.org> <http://feross.org>
+ * @author   Feross Aboukhadijeh <https://feross.org>
  * @license  MIT
  */
 /* eslint-disable no-proto */

--- a/dpcc-web.js
+++ b/dpcc-web.js
@@ -39,6 +39,7 @@ services.forEach(function (service, index) {
 
 
 get_service_inputs().forEach(function (element, index) {
+  window.service[element.name] = +element.value;
   element.onchange = function (event) {
     window.service[element.name] = +this.value;
     display_costs();
@@ -47,6 +48,7 @@ get_service_inputs().forEach(function (element, index) {
 
 
 get_user_inputs().forEach(function (element, index) {
+  window.user[element.name] = +element.value;
   element.onchange = function (event) {
     window.user[element.name] = +this.value;
     display_costs();


### PR DESCRIPTION
Use the current values in the text input fields at page load time to initialize
the user and service objects that are used as inputs to the get_costs function.
This way, we avoid "NaN" and similar errors on a soft page reload, where the
browser retains the last-used values in the text input fields.