### PR TITLE
Modified rates and added notes object to services.

### DIFF
--- a/services.json
+++ b/services.json
@@ -1,122 +1,134 @@
 [
     {
-    "name": "DivIT",
-	"service": {
-		"ingest_rate": 200,
-		"membership_fee": 0,
+    "name": "Local Storage",
+    "service": {
+        "ingest_rate": 200,
+        "membership_fee": 0,
         "storage_rate": 33.84,
         "included_storage": 0,
-        "storage_increment": 1
+        "storage_increment": 1,
+        "note":
         }
-	},
-	{
-	"name": "APTrust",
-	"service": {
-		"ingest_rate": 0,
-		"membership_fee": 20000,
-		"storage_rate": 550,
-		"included_storage": 10,
-		"storage_increment": 1
-		}
-	},
-	{
-	"name": "DPN Annual",
-	"service": {
-		"ingest_rate": 0,
-		"membership_fee": 20000,
-		"storage_rate": 750,
-		"included_storage": 5,
-		"storage_increment": 1
-		}
-	},        
-	{
-	"name": "DPN Perpetual",
-	"service": {
-		"ingest_rate": 0,
-		"membership_fee": 20000,
-		"storage_rate": 5000,
-		"included_storage": 5,
-		"storage_increment": 1
-		}
-	},
-	{
-	"name": "DuraCloud Enterprise (S3)",
-	"service": {
-		"ingest_rate": 0,
-		"membership_fee": 5250,
-		"storage_rate": 500,
-		"included_storage": 0,
-		"storage_increment": 1
-		}
-	},
-	{
-	"name": "DuraCloud Enterprise Plus (S3 + Glacier)",
-	"service": {
-		"ingest_rate": 0,
-		"membership_fee": 5250,
-		"storage_rate": 625,
-		"included_storage": 0,
-		"storage_increment": 1
-		}
-	},
-	{
-	"name": "DuraCloud Enterprise Plus (S3 + SDSC)",
-	"service": {
-		"ingest_rate": 0,
-		"membership_fee": 5550,
-		"storage_rate": 1200,
-		"included_storage": 0,
-		"storage_increment": 1
-		}
-	},
-	{
-	"name": "DuraCloud Enterprise Chronopolis",
-	"service": {
-	    "ingest_rate": 310,
-		"membership_fee": 2750,
-		"storage_rate": 500,
-		"included_storage": 0,
-		"storage_increment": 1
-		}
-	},
-	{
-	"name": "Preservica Standard (S3)",
-	"service": {
-		"ingest_rate": 0,
-		"membership_fee": 11950,
-		"storage_rate": 1450,
-		"included_storage": 1,
-		"storage_increment": 1
-		}
-	},
-	{
-	"name": "Preservica Standard (S3 + Glacier)",
-	"service": {
-		"ingest_rate": 0,
-		"membership_fee": 11950,
-		"storage_rate": 2000,
-		"included_storage": 1,
-		"storage_increment": 1
-		}
-	},
-	{
-	"name": "Preservica Standard (Glacier)",
-	"service": {
-		"ingest_rate": 0,
-		"membership_fee": 11950,
-		"storage_rate": 550,
-		"included_storage": 1,
-		"storage_increment": 1
-		}
-	},
-	{
-	"name": "Preservica Volume (S3 + Glacier)",
-	"service": {
-		"ingest_rate": 0,
-		"membership_fee": 11950,
-		"storage_rate": 1200,
-		"included_storage": 1,
-		"storage_increment": 1
-		}
-	}
+    },
+    {
+    "name": "APTrust",
+    "service": {
+        "ingest_rate": 0,
+        "membership_fee": 20000,
+        "storage_rate": 420,
+        "included_storage": 10,
+        "storage_increment": 1,
+        "note":
+        }
+    },
+    {
+    "name": "DPN Annual",
+    "service": {
+        "ingest_rate": 0,
+        "membership_fee": 20000,
+        "storage_rate": 750,
+        "included_storage": 5,
+        "storage_increment": 1,
+        "note":
+        }
+    },
+    {
+    "name": "DPN Perpetual",
+    "service": {
+        "ingest_rate": 5000,
+        "membership_fee": 20000,
+        "storage_rate": 0,
+        "included_storage": 5,
+        "storage_increment": 1,
+        "note": "DPN Perpetual is only rated for a 20 year projection in this model."
+        }
+    },
+    {
+    "name": "DuraCloud Enterprise (S3)",
+    "service": {
+        "ingest_rate": 0,
+        "membership_fee": 5250,
+        "storage_rate": 500,
+        "included_storage": 0,
+        "storage_increment": 1,
+        "note":
+        }
+    },
+    {
+    "name": "DuraCloud Enterprise Plus (S3 + Glacier)",
+    "service": {
+        "ingest_rate": 0,
+        "membership_fee": 5250,
+        "storage_rate": 625,
+        "included_storage": 0,
+        "storage_increment": 1,
+        "note":
+        }
+    },
+    {
+    "name": "DuraCloud Enterprise Plus (S3 + SDSC)",
+    "service": {
+        "ingest_rate": 0,
+        "membership_fee": 5550,
+        "storage_rate": 1200,
+        "included_storage": 0,
+        "storage_increment": 1,
+        "note":
+        }
+    },
+    {
+    "name": "DuraCloud Enterprise Chronopolis",
+    "service": {
+        "ingest_rate": 310,
+        "membership_fee": 2750,
+        "storage_rate": 500,
+        "included_storage": 0,
+        "storage_increment": 1,
+        "note":
+        }
+    },
+    {
+    "name": "Preservica Standard (S3)",
+    "service": {
+        "ingest_rate": 0,
+        "membership_fee": 11950,
+        "storage_rate": 1450,
+        "included_storage": 1,
+        "storage_increment": 1,
+        "note":
+        }
+    },
+    {
+    "name": "Preservica Standard (S3 + Glacier)",
+    "service": {
+        "ingest_rate": 0,
+        "membership_fee": 11950,
+        "storage_rate": 2000,
+        "included_storage": 1,
+        "storage_increment": 1,
+        "note":
+        }
+    },
+    {
+    "name": "Preservica Standard (Glacier)",
+    "service": {
+        "ingest_rate": 0,
+        "membership_fee": 11950,
+        "storage_rate": 550,
+        "included_storage": 1,
+        "storage_increment": 1,
+        "note":
+        }
+    },
+    {
+    "name": "Preservica Volume (S3 + Glacier)",
+    "service": {
+        "ingest_rate": 0,
+        "membership_fee": 11950,
+        "storage_rate": 1200,
+        "included_storage": 1,
+        "storage_increment": 1,
+        "note":
+        }
+    }
 ]


### PR DESCRIPTION
In our meeting last week, Kate mentioned that the rate for APTrust should be changed. Also, DPN Perpetual required the ingest and storage rates should be swapped. An explanatory notes field was also added.